### PR TITLE
Adding options to specify slurm account and slurm job submission timeout

### DIFF
--- a/tools/templates/all.ctrl
+++ b/tools/templates/all.ctrl
@@ -87,6 +87,9 @@ slurm_array_job_size=1
 # Maximum number of concurrent jobs from a single array job
 # that should be run
 
+slurm_job_submission_timeout=10
+# Timeout for submission of slurm jobs
+
 
 ************************************************
 ** Storage configuration

--- a/tools/templates/all.ctrl
+++ b/tools/templates/all.ctrl
@@ -74,6 +74,9 @@ slurm_template=./templates/template1.slurm.sh
 slurm_array_job_throttle=1
 # Maximum number of jobs running within a single slurm array job
 
+slurm_account=
+# Slurm account to use. If not set, default account is used
+
 slurm_partition=standard96
 # Partition to submit the job
 

--- a/tools/templates/template1.slurm.sh
+++ b/tools/templates/template1.slurm.sh
@@ -39,6 +39,7 @@
 ##SBATCH --partition={{slurm_partition}}
 #SBATCH --output={{batch_workunit_base}}/%A_%a.out
 #SBATCH --error={{batch_workunit_base}}/%A_%a.err
+#SBATCH --account={{slurm_account}}
 
 
 # If you are using a virtualenv, make sure the correct one 

--- a/tools/vflp_submit_jobs.py
+++ b/tools/vflp_submit_jobs.py
@@ -83,6 +83,7 @@ def submit_slurm(config, client, current_workunit, jobline):
 		"array_start": "0",
 		"array_end": (subjobs_count - 1),
 		"slurm_cpus": config['slurm_cpus'],
+		"slurm_account": config['slurm_account'],
 		"slurm_partition": config['slurm_partition'],
 		"workunit_id": jobline_str,
 		"job_storage_mode": config['job_storage_mode'],

--- a/tools/vflp_submit_jobs.py
+++ b/tools/vflp_submit_jobs.py
@@ -112,7 +112,7 @@ def submit_slurm(config, client, current_workunit, jobline):
 
 	try:
 		ret = subprocess.run(cmd, capture_output=True,
-					text=True, timeout=5)
+					text=True, timeout=int(config['slurm_job_submission_timeout']))
 	except subprocess.TimeoutExpired as err:
 		raise Exception("timeout on submission to sbatch")
 


### PR DESCRIPTION
User can specify `slurm_account` and `slurm_job_submission_timeout` in `all.ctrl` file